### PR TITLE
Remove products scope for inventory_items webhooks

### DIFF
--- a/metadatas/2025-04/inventory_items/create.json
+++ b/metadatas/2025-04/inventory_items/create.json
@@ -1,7 +1,6 @@
 {
   "access_scopes": [
-    "inventory",
-    "products"
+    "inventory"
   ],
   "available_on": [
     "graphql",

--- a/metadatas/2025-04/inventory_items/delete.json
+++ b/metadatas/2025-04/inventory_items/delete.json
@@ -1,7 +1,6 @@
 {
   "access_scopes": [
-    "inventory",
-    "products"
+    "inventory"
   ],
   "available_on": [
     "graphql",

--- a/metadatas/2025-04/inventory_items/update.json
+++ b/metadatas/2025-04/inventory_items/update.json
@@ -1,7 +1,6 @@
 {
   "access_scopes": [
-    "inventory",
-    "products"
+    "inventory"
   ],
   "available_on": [
     "graphql",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shopify-webhook-schemas",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "",
   "main": "dist/src/index.js",
   "type": "commonjs",


### PR DESCRIPTION
After running a recent scrape it seems the shopify rails metadata says that the `products` scope is a possible access scope you can use to register `inventory_items` webhooks. This isn't true, and also breaks some of our test coverage for checking if `scopesForWebhooks` on a model's metadata contains the possible access scopes that Shopify says there is. We should remove this so it keeps the current expected behaviour and not break anything webhook registration wise.